### PR TITLE
magnetometer data now comes in (X,Y,Z) order instead of (X,Z,Y) order

### DIFF
--- a/Adafruit_LSM303/LSM303.py
+++ b/Adafruit_LSM303/LSM303.py
@@ -81,9 +81,11 @@ class LSM303(object):
         # Convert to 12-bit values by shifting unused bits.
         accel = (accel[0] >> 4, accel[1] >> 4, accel[2] >> 4)
         # Read the magnetometer.
+        # Note that for some reason the LSM303 returns data in (X,Z,Y) order
         mag_raw = self._mag.readList(LSM303_REGISTER_MAG_OUT_X_H_M, 6)
-        mag = struct.unpack('>hhh', mag_raw)
-        return (accel, mag)
+        magX, magZ, magY = struct.unpack('>hhh', mag_raw)
+        reordered_mag = magX, magY, magZ
+        return (accel, reordered_mag)
 
     def set_mag_gain(gain=LSM303_MAGGAIN_1_3):
         """Set the magnetometer gain.  Gain should be one of the following


### PR DESCRIPTION
I fixed a (serious) bug where the magnetometer data was returned in the incorrect order. According to the [docstring](https://github.com/adafruit/Adafruit_Python_LSM303/blob/master/Adafruit_LSM303/LSM303.py#L76) for the read function, the data should be returned in (X, Y, Z) order, which is both logical and also consistent with the order of the acceleration data. However, the LSM303 must actually feed data in (X, Z, Y) order, because that is what you get straight out of the [`struct.unpack()`](https://github.com/adafruit/Adafruit_Python_LSM303/blob/master/Adafruit_LSM303/LSM303.py#L85) call. This may have slipped under the rug because in the example the magnetometer data is quietly parsed in (X, Z, Y) order, so it works. 

All I did was unpack the magnetometer tuple and reorder the components so it is in proper (X, Y, Z) order. Although this could break compatibility with some users' code, this seems like such a blatant bug that it should be corrected. I just wasted about 5 hours because of this bug, and I'd imagine others could do this too! At lease the docstring for the `read()` function should be corrected. 