### PR TITLE
The example now uses correct order magnetometer data

### DIFF
--- a/examples/simpletest.py
+++ b/examples/simpletest.py
@@ -21,7 +21,7 @@ while True:
     accel, mag = lsm303.read()
     # Grab the X, Y, Z components from the reading and print them out.
     accel_x, accel_y, accel_z = accel
-    mag_x, mag_z, mag_y = mag
+    mag_x, mag_y, mag_z = mag
     print('Accel X={0}, Accel Y={1}, Accel Z={2}, Mag X={3}, Mag Y={4}, Mag Z={5}'.format(
           accel_x, accel_y, accel_z, mag_x, mag_y, mag_z))
     # Wait half a second and repeat.


### PR DESCRIPTION
Fixed the example so it actually parses the magnetometer data in XYZ order